### PR TITLE
Enforce language standard.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -84,12 +84,12 @@ XLIBD    := ../../branch8b/sw/zlib
 XLIBS    := -L$(XLIBD) -Wl,--start-group -Wl,--Map=zip-tttt.map -larty
 LDSCRIPT := $(XLIBD)/../board/arty.ld
 XFLAGS   := -T$(LDSCRIPT)
-CFLAGS  := -O3 -Wall
+CFLAGS  := -O3 -Wall -std=c99
 else
 XLIBD   :=
 XLIBS  :=
 XFLAGS :=
-CFLAGS  := -g -Og -Wall
+CFLAGS  := -g -Og -Wall -std=c99
 endif
 
 


### PR DESCRIPTION
Not all GCC deployments respect C99 or later by default.  This
patch enforces the minimum supported C langauge standard.